### PR TITLE
Dealing with SVG elements

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -309,8 +309,6 @@ Parser.prototype.reset = function(){
 	this._attribs = null;
 	this._stack = [];
 
-	this._insideSVG = 0;
-
 	if(this._cbs.onparserinit) this._cbs.onparserinit(this);
 };
 

--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -76,18 +76,7 @@ var voidElements = {
 	param: true,
 	source: true,
 	track: true,
-	wbr: true,
-
-	//common self closing svg elements
-	path: true,
-	circle: true,
-	ellipse: true,
-	line: true,
-	rect: true,
-	use: true,
-	stop: true,
-	polyline: true,
-	polygon: true
+	wbr: true
 };
 
 var re_nameEnd = /\s|\//;

--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -91,9 +91,6 @@ function Parser(cbs, options){
 	this._attribs = null;
 	this._stack = [];
 
-	// All elements that are wrapped inside the SVG tag should be parsed as XML document.
-	this._insideSVG = 0;
-
 	this.startIndex = 0;
 	this.endIndex = null;
 
@@ -132,10 +129,6 @@ Parser.prototype.ontext = function(data){
 };
 
 Parser.prototype.onopentagname = function(name){
-	if (/svg/i.test(name)){
-		this._insideSVG++;
-	}
-
 	if(this._lowerCaseTagNames){
 		name = name.toLowerCase();
 	}
@@ -174,10 +167,6 @@ Parser.prototype.onopentagend = function(){
 };
 
 Parser.prototype.onclosetag = function(name){
-	if (/svg/i.test(name)){
-		this._insideSVG--;
-	}
-
 	this._updatePosition(1);
 
 	if(this._lowerCaseTagNames){
@@ -203,7 +192,9 @@ Parser.prototype.onclosetag = function(name){
 };
 
 Parser.prototype.onselfclosingtag = function(){
-	if(!!this._insideSVG || this._options.xmlMode || this._options.recognizeSelfClosing){
+	// All elements that are wrapped in <math> or <svg> tags should be parsed as XML document.
+	var xmlMode = (this._options.xmlMode || /\b(math|svg)\b/i.test(this._stack.join()));
+	if(xmlMode || this._options.recognizeSelfClosing){
 		this._closeCurrentTag();
 	} else {
 		this.onopentagend();

--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -91,6 +91,9 @@ function Parser(cbs, options){
 	this._attribs = null;
 	this._stack = [];
 
+	// All elements that are wrapped inside the SVG tag should be parsed as XML document.
+	this._insideSVG = 0;
+
 	this.startIndex = 0;
 	this.endIndex = null;
 
@@ -129,6 +132,10 @@ Parser.prototype.ontext = function(data){
 };
 
 Parser.prototype.onopentagname = function(name){
+	if (/svg/i.test(name)){
+		this._insideSVG++;
+	}
+
 	if(this._lowerCaseTagNames){
 		name = name.toLowerCase();
 	}
@@ -167,6 +174,10 @@ Parser.prototype.onopentagend = function(){
 };
 
 Parser.prototype.onclosetag = function(name){
+	if (/svg/i.test(name)){
+		this._insideSVG--;
+	}
+
 	this._updatePosition(1);
 
 	if(this._lowerCaseTagNames){
@@ -192,7 +203,7 @@ Parser.prototype.onclosetag = function(name){
 };
 
 Parser.prototype.onselfclosingtag = function(){
-	if(this._options.xmlMode || this._options.recognizeSelfClosing){
+	if(!!this._insideSVG || this._options.xmlMode || this._options.recognizeSelfClosing){
 		this._closeCurrentTag();
 	} else {
 		this.onopentagend();
@@ -306,6 +317,8 @@ Parser.prototype.reset = function(){
 	this._attribname = "";
 	this._attribs = null;
 	this._stack = [];
+
+	this._insideSVG = 0;
 
 	if(this._cbs.onparserinit) this._cbs.onparserinit(this);
 };

--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -192,9 +192,10 @@ Parser.prototype.onclosetag = function(name){
 };
 
 Parser.prototype.onselfclosingtag = function(){
-	// All elements that are wrapped in <math> or <svg> tags should be parsed as XML document.
-	var xmlMode = (this._options.xmlMode || /\b(math|svg)\b/i.test(this._stack.join()));
-	if(xmlMode || this._options.recognizeSelfClosing){
+	// Element that is wrapped in <math> or <svg> tag is foreign element and can
+	// be recognized as self-closing tag.
+	var isForeignElement = /\b(math|svg)\b/i.test(this._stack.join());
+	if(this._options.xmlMode || this._options.recognizeSelfClosing || isForeignElement){
 		this._closeCurrentTag();
 	} else {
 		this.onopentagend();

--- a/test/Events/32-svg_nested.json
+++ b/test/Events/32-svg_nested.json
@@ -1,0 +1,63 @@
+{
+  "name": "Nested SVG element",
+  "options": {
+    "handler": {},
+    "parser": {}
+  },
+  "html": "<use xlink:href=/icon.svg><title>SVG Icon</title></use>",
+  "expected": [
+    {
+      "event": "opentagname",
+      "data": [
+        "use"
+      ]
+    },
+    {
+      "event": "attribute",
+      "data": [
+        "xlink:href",
+        "/icon.svg"
+      ]
+    },
+    {
+      "event": "opentag",
+      "data": [
+        "use",
+        {
+          "xlink:href": "/icon.svg"
+        }
+      ]
+    },
+    {
+      "event": "opentagname",
+      "data": [
+        "title"
+      ]
+    },
+    {
+      "event": "opentag",
+      "data": [
+        "title",
+        {}
+      ]
+    },
+    {
+      "event": "text",
+      "data": [
+        "SVG Icon"
+      ]
+    },
+    {
+      "event": "closetag",
+      "data": [
+        "title"
+      ]
+    },
+    {
+      "event": "closetag",
+      "data": [
+        "use"
+      ]
+    }
+  ]
+}

--- a/test/Events/32-svg_nested.json
+++ b/test/Events/32-svg_nested.json
@@ -4,8 +4,21 @@
     "handler": {},
     "parser": {}
   },
-  "html": "<use xlink:href=/icon.svg><title>SVG Icon</title></use>",
+  "html": "<svg><use xlink:href=/icon.svg><title>SVG Icon</title></use></svg>",
   "expected": [
+    {
+      "event": "opentagname",
+      "data": [
+        "svg"
+      ]
+    },
+    {
+      "event": "opentag",
+      "data": [
+        "svg",
+        {}
+      ]
+    },
     {
       "event": "opentagname",
       "data": [
@@ -57,6 +70,12 @@
       "event": "closetag",
       "data": [
         "use"
+      ]
+    },
+    {
+      "event": "closetag",
+      "data": [
+        "svg"
       ]
     }
   ]

--- a/test/Events/33-svg_self_closing.json
+++ b/test/Events/33-svg_self_closing.json
@@ -1,0 +1,66 @@
+{
+  "name": "Self-closing SVG element",
+  "options": {
+    "handler": {},
+    "parser": {}
+  },
+  "html": "<use xlink:href=/background.svg /><use xlink:href=/icon.svg />",
+  "expected": [
+    {
+      "event": "opentagname",
+      "data": [
+        "use"
+      ]
+    },
+    {
+      "event": "attribute",
+      "data": [
+        "xlink:href",
+        "/background.svg"
+      ]
+    },
+    {
+      "event": "opentag",
+      "data": [
+        "use",
+        {
+          "xlink:href": "/background.svg"
+        }
+      ]
+    },
+    {
+      "event": "closetag",
+      "data": [
+        "use"
+      ]
+    },
+    {
+      "event": "opentagname",
+      "data": [
+        "use"
+      ]
+    },
+    {
+      "event": "attribute",
+      "data": [
+        "xlink:href",
+        "/icon.svg"
+      ]
+    },
+    {
+      "event": "opentag",
+      "data": [
+        "use",
+        {
+          "xlink:href": "/icon.svg"
+        }
+      ]
+    },
+    {
+      "event": "closetag",
+      "data": [
+        "use"
+      ]
+    }
+  ]
+}

--- a/test/Events/33-svg_self_closing.json
+++ b/test/Events/33-svg_self_closing.json
@@ -4,8 +4,21 @@
     "handler": {},
     "parser": {}
   },
-  "html": "<use xlink:href=/background.svg /><use xlink:href=/icon.svg />",
+  "html": "<svg><use xlink:href=/background.svg /><use xlink:href=/icon.svg /></svg>",
   "expected": [
+    {
+      "event": "opentagname",
+      "data": [
+        "svg"
+      ]
+    },
+    {
+      "event": "opentag",
+      "data": [
+        "svg",
+        {}
+      ]
+    },
     {
       "event": "opentagname",
       "data": [
@@ -60,6 +73,12 @@
       "event": "closetag",
       "data": [
         "use"
+      ]
+    },
+    {
+      "event": "closetag",
+      "data": [
+        "svg"
       ]
     }
   ]


### PR DESCRIPTION
htmlparser2 doesn’t parse SVG elements correctly. Before having a proper fix for it, we check these two test cases first:
1. `<use xlink:href=/icon.svg><title>SVG Icon</title></use>`
2. `<use xlink:href=/background.svg /><use xlink:href=/icon.svg />`

Above are valid SVG examples. For more detail on (1), check http://www.w3.org/TR/SVG/struct.html#UseElement. Most SVG elements have content model which allow them to have child elements.

htmlparser2 is a SAX parser. Their test cases are quite hard to check so I briefly describe the output we're expecting here:
1. open `<use>`, open `<title>`, close `<title>`, close `<use>`.
2. open 1st `<use>`, close 1st `<use>`, open 2nd `<use>`, close 2nd `<use>`.

The current htmlparser2 code can’t deal with (1), always closes `<use>` before opening `<title>`. It’s because of these lines: https://github.com/broadly/htmlparser2/blob/master/lib/Parser.js#L81-L90. SVG elements can’t be void and not always be seft-closing, so we should remove them from the list.

But after the fix, we get another problem, (2) becomes nested. To quote from https://github.com/anvoz/htmlparser2/pull/1:

> In HTML5, self-closing tag is only available for foreign elements (SVG elements). So `<p/>Foo</p>` means `<p>Foo</p>` (A), but `<use xlink:href=/background.svg />` means `<use xlink:href=/background.svg></use>` (B). We can't support both (A) and (B). If we support (A), we can't parse SVG elements correctly. If we drop (A) and support (B), we can deal with most cases, (A) becomes something like `<p></p><p>Foo</p>`. But (A) is quite a rare case.

*_not `<p></p><p>Foo</p>`, but `<p></p>Foo<p></p>`_

So we should always recognize self-closing tag, or default it to true.
